### PR TITLE
doc: fix readme indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@
 - 接口源：
 
 ```bash
-  https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/output/result.m3u
+https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/output/result.m3u
 ```
 
 - 数据源：
 
 ```bash
-  https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/source.json
+https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/source.json
 ```
 
 ## 配置

--- a/README_en.md
+++ b/README_en.md
@@ -91,13 +91,13 @@
 - Interface source:
 
 ```bash
-  https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/output/result.m3u
+https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/output/result.m3u
 ```
 
 - Data source:
 
 ```bash
-  https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/source.json
+https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/source.json
 ```
 
 ## Config


### PR DESCRIPTION
## 问题描述
在 `README.md` 文件中，接口源和数据源的 URL 前面有多余的空格。当用户点击复制图标时，这些空格也会被复制，导致 VLC 应用在解析 URL 时抛出异常。
<img width="870" alt="image" src="https://github.com/user-attachments/assets/676ff43a-7545-46f9-9bce-f85274e663ec">

<img width="704" alt="image" src="https://github.com/user-attachments/assets/a14473f6-f476-49f3-853c-440407df099c">

## 解决方案
#### 修改前
- 接口源：

```bash
  https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/output/result.m3u
```

- 数据源：

```bash
  https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/source.json
```
#### 修改后
- 接口源：

```bash
https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/output/result.m3u
```

- 数据源：

```bash
https://ghproxy.net/raw.githubusercontent.com/Guovin/TV/gd/source.json
```